### PR TITLE
Added npmignore and exclude builds and tests from distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.*/
+test/
+.eslintrc.js


### PR DESCRIPTION
**Added a `.npmignore`, because I noticed we distribute some unnecessary files.**
Priority low, no release required.

Screenshot with the unnecessary files, from the node_modules folder:

![image](https://user-images.githubusercontent.com/13376471/106176533-b8019700-6197-11eb-85e6-d38645148e35.png)

**The package got smaller:**
Size before:
package size:  5.4 kB                                  
unpacked size: 12.0 kB 

Size after:
package size:  1.9 kB                                  
unpacked size: 4.7 kB    

