### PR TITLE
Link repo in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "keywords": ["node-red", "bavaria-black"],
   "author": "Bavaria Black",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Bavaria-Black/node-red-ext-bavaria-black"
+  },
   "devDependencies": {
     "mocha": "^8.1.3"
   }

--- a/src/converter.js
+++ b/src/converter.js
@@ -50,7 +50,7 @@ module.exports = {
                 r: 0,
                 g: 0,
                 b: 0
-            }
+            };
         }
 
         var int16 = parseInt(hex, 16);
@@ -58,6 +58,6 @@ module.exports = {
             r: (int16 >> 16) & 255,
             g: (int16 >> 8) & 255,
             b: int16 & 255
-        }
+        };
     }
 };

--- a/src/observer.js
+++ b/src/observer.js
@@ -2,7 +2,7 @@ module.exports = {
     _idCounter: 0,
     _subs: [],
     register : function(topic, callback){
-        var id = this._idCounter++
+        var id = this._idCounter++;
         this._subs.push({
             id: id,
             topic: topic,
@@ -27,7 +27,7 @@ module.exports = {
     notify: function(topic, msg) {
         this._subs.forEach(element => {
             if(element.topic === topic) {
-                element.callback(msg)
+                element.callback(msg);
             }
         });
     }

--- a/src/validators.js
+++ b/src/validators.js
@@ -2,7 +2,7 @@ module.exports ={
     range : function(min, max) {
         return function(v) { 
             return v <= max && v >= min;
-        }   
+        };
     },
     test: function(){
         return 555;


### PR DESCRIPTION
Added a link to the repo in the package.json, so the GitHub repo will be linked in NPM.
The main reason to do this, so users can find the repo to create issues when they look for it on NPM.
Resolves #2 

Also added some missing semicolons.
